### PR TITLE
respect to portage defaults

### DIFF
--- a/lib/Gentoo/Portage.pm
+++ b/lib/Gentoo/Portage.pm
@@ -38,8 +38,8 @@ our @EXPORT =
 our $VERSION = '0.01';
 
 
+# import ENV variables
 sub getEnv {
-#IMPORT VARIABLES
     my $self = shift;
     my $envvar = shift;
     my $filter = sub {
@@ -47,7 +47,12 @@ sub getEnv {
         return($var =~ /^$envvar$/ );
     };
 
-    foreach my $file ( "$ENV{HOME}/.gcpanrc", '/etc/portage/make.conf', '/etc/make.conf', '/etc/make.globals' ) {
+    foreach my $file (
+        "$ENV{HOME}/.gcpanrc", '/etc/portage/make.conf',
+        '/etc/make.conf',      '/etc/make.globals',
+        '/usr/share/portage/config/make.globals'    # system-wide defaults for the Portage system
+      )
+    {
         if ( -f $file ) {
             my $importer = Shell::EnvImporter->new(
                 file          => $file,

--- a/lib/Gentoo/Portage.pm
+++ b/lib/Gentoo/Portage.pm
@@ -47,24 +47,22 @@ sub getEnv {
         return($var =~ /^$envvar$/ );
     };
 
-foreach my $file ( "$ENV{HOME}/.gcpanrc", '/etc/portage/make.conf', '/etc/make.conf', '/etc/make.globals' ) {
-    if ( -f $file) {
-    	my $importer = Shell::EnvImporter->new(
-    		file => $file,
-    		shell => 'bash',
-            import_filter => $filter,
-    	);
-    $importer->shellobj->envcmd('set');
-    $importer->run();
-    if (defined($ENV{$envvar}) && ($ENV{$envvar} =~ m{\W*}))
-    { 
-        my $tm = strip_env($ENV{$envvar}); 
-        $importer->restore_env; 
-        return $tm;
+    foreach my $file ( "$ENV{HOME}/.gcpanrc", '/etc/portage/make.conf', '/etc/make.conf', '/etc/make.globals' ) {
+        if ( -f $file ) {
+            my $importer = Shell::EnvImporter->new(
+                file          => $file,
+                shell         => 'bash',
+                import_filter => $filter,
+            );
+            $importer->shellobj->envcmd('set');
+            $importer->run();
+            if ( defined( $ENV{$envvar} ) && ( $ENV{$envvar} =~ m{\W*} ) ) {
+                my $tm = strip_env( $ENV{$envvar} );
+                $importer->restore_env;
+                return $tm;
+            }
+        }
     }
-
-}
-  }
 }
 
 sub strip_env {

--- a/t/10cpan_packages.t
+++ b/t/10cpan_packages.t
@@ -31,7 +31,7 @@ else {
     }
     else
     {
-        plan tests => 8;
+        plan tests => 9;
     }
 }
 
@@ -47,9 +47,8 @@ use_ok(' Gentoo');
 my $GC = Gentoo->new();
 ok( defined($GC), 'new() works' );
 
-
-# Can we get the PORTDIR value?
-ok( $GC->getEnv("PORTDIR"), 'getEnv("PORTDIR") worked' );
+ok( $GC->getEnv('PORTDIR'), 'getEnv("PORTDIR") worked' );
+ok( $GC->getEnv('DISTDIR'), 'getEnv("DISTDIR") worked' );
 
 $GC->getCPANInfo($module);
 # Test getting the contents of a directory


### PR DESCRIPTION
Add 'make.globals' to the list of scanned ENV files.
This is allow to catch some variables which usually is not set in make.conf.
For example 'DISTDIR'.