### PR TITLE
Turn \t into space.

### DIFF
--- a/lib/Gentoo/Portage.pm
+++ b/lib/Gentoo/Portage.pm
@@ -71,14 +71,14 @@ sub strip_env {
     my $key = shift;
     return $key unless defined($key);
     if (defined($ENV{$key})) {
-        $ENV{$key} =~ s{\\n}{ }gxms;
+        $ENV{$key} =~ s{\\n|\\t}{ }gxms;
         $ENV{$key} =~ s{\\|\'|\\'|\$|\s*$}{}gmxs;
         $key =~ s{\s+}{ }gmxs;
         return $ENV{$key};
     }
     else
     {
-        $key =~ s{\\n}{ }gxms;
+        $key =~ s{\\n|\\t}{ }gxms;
         $key =~ s{(\'|\\|\\'|\$|\s*$)}{}gmxs;
         $key =~ s{\s+}{ }gmxs;
         return $key;


### PR DESCRIPTION
_See also [Gentoo bug 526192](https://bugs.gentoo.org/show_bug.cgi?id=526192)._

Even after fixing the warnings from [bug 526188](https://bugs.gentoo.org/show_bug.cgi?id=526188) a.k.a. issue #6, g-cpan reports

```
* DEFINED OVERLAYS DON'T EXIST!
```

This is because the `PORTDIR_OVERLAY` variable in my make.conf contains tabs. `set` reports these as `$'…\t…'` and `strip_env` from `Gentoo::Portage` (as installed by g-cpan) removes the `\` but keeps the `t`. So I guess we should add `\\t` to the `\\n` handling in there.

---

_Note_ that this whole `strip_env` function looks somewhat suspicious to me. As far as I can tell, it is only ever called with the _value_ of the environment variable as an argument, never with its _name_. In that case, looking for `$ENV{$key}` might be one redirection too many, and cause surprising results. And modifying the key after we tweaked the environment setting for the unmodified key looks even stranger. Can we simply drop the whole first case of that if…else construct, and execute the second case unconditionally? Perhaps renaming `$key` to `$val` in the process? Or am I missing some point here?
