### PR TITLE
escape the quotes inside DESCRIPTION (fix Gentoo bug #431080)

### DIFF
--- a/bin/g-cpan
+++ b/bin/g-cpan
@@ -720,6 +720,7 @@ sub generatePackageInfo
 
                         my $module_version = $gcpan_run->{cpan}{lc($original_ebuild)}{version};
                         my $description = $gcpan_run->{'cpan'}{lc($original_ebuild)}{'description'};
+                        $description =~ s/"/\\"/g;
 
                         print $EBUILD <<"HERE";
 # Copyright 1999-2014 Gentoo Foundation


### PR DESCRIPTION
https://bugs.gentoo.org/show_bug.cgi?id=431080