### PR TITLE
add coveralls.io badge (status image)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Coverage Status](https://coveralls.io/repos/gentoo-perl/g-cpan/badge.png?branch=master)](https://coveralls.io/r/gentoo-perl/g-cpan?branch=master)
+
 ### NAME
 
 g-cpan - generate and install CPAN modules using portage


### PR DESCRIPTION
Settings for the coveralls.io was added by #11 .
Required additional actions: register repo at coveralls.io.

Example: https://coveralls.io/r/bor/g-cpan